### PR TITLE
fix: replace remaining jose imports in tests with PyJWT

### DIFF
--- a/backend/tests/unit/test_auth_middleware.py
+++ b/backend/tests/unit/test_auth_middleware.py
@@ -26,7 +26,7 @@ Test Coverage:
 import pytest
 from fastapi import status, HTTPException
 from datetime import datetime, timedelta
-from jose import jwt
+import jwt
 
 
 @pytest.mark.unit

--- a/backend/tests/unit/test_oauth_handler.py
+++ b/backend/tests/unit/test_oauth_handler.py
@@ -253,7 +253,7 @@ class TestJWTTokenGeneration:
         """
         from app.models.user import User
         from app.auth import create_access_token
-        from jose import jwt
+        import jwt
         from app.config import settings
 
         user = User(
@@ -287,7 +287,7 @@ class TestJWTTokenGeneration:
         """
         from app.models.user import User
         from app.auth import create_access_token
-        from jose import jwt
+        import jwt
         from app.config import settings
         from datetime import datetime
 


### PR DESCRIPTION
Two test files still imported from jose after the python-jose → PyJWT migration. Updated to use `import jwt` directly.