### PR TITLE
Show persona avatars in private conversation view

### DIFF
--- a/frontend/src/components/conversation/ConversationView.tsx
+++ b/frontend/src/components/conversation/ConversationView.tsx
@@ -81,7 +81,20 @@ export function ConversationView({
             No messages yet — click &ldquo;Next Turn&rdquo; to start the conversation.
           </p>
         ) : (
-          messages.map((msg) => <MessageBubble key={msg.id} message={msg} />)
+          (() => {
+            const avatarMap = Object.fromEntries(
+              (conversation.participants ?? [])
+                .filter((p) => p.persona_name)
+                .map((p) => [p.persona_name!, p.avatar_url])
+            );
+            return messages.map((msg) => (
+              <MessageBubble
+                key={msg.id}
+                message={msg}
+                avatarUrl={avatarMap[msg.persona_name]}
+              />
+            ));
+          })()
         )}
         <div ref={bottomRef} />
       </div>


### PR DESCRIPTION
Resolved the discrepancy between the private and public conversation views where persona display pictures were missing from the private view. Updated `ConversationView.tsx` to correctly extract avatar URLs from the conversation's participant data and pass them to the `MessageBubble` component. Verified the fix with a successful frontend build and passing unit tests.

Fixes #67

---
*PR created automatically by Jules for task [10633191687768408585](https://jules.google.com/task/10633191687768408585) started by @JamesTwisleton*