### PR TITLE
Add typing indicators and progress feedback during AI generation

### DIFF
--- a/frontend/src/components/conversation/ConversationView.tsx
+++ b/frontend/src/components/conversation/ConversationView.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Conversation } from "@/types";
 import { MessageBubble } from "./MessageBubble";
 import { Button } from "@/components/ui/Button";
+import { TypingIndicator } from "./TypingIndicator";
 
 interface ConversationViewProps {
   conversation: Conversation;
@@ -28,12 +29,12 @@ export function ConversationView({
   const [showVisibilityModal, setShowVisibilityModal] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
 
-  // Scroll to bottom whenever messages change
+  // Scroll to bottom whenever messages change or loading state changes
   useEffect(() => {
     if (bottomRef.current && typeof bottomRef.current.scrollIntoView === 'function') {
       bottomRef.current.scrollIntoView({ behavior: "smooth" });
     }
-  }, [messages.length]);
+  }, [messages.length, isLoading]);
 
   const handleSend = async () => {
     const text = inputText.trim();
@@ -167,7 +168,7 @@ export function ConversationView({
 
       {/* Messages */}
       <div className="space-y-3">
-        {messages.length === 0 ? (
+        {messages.length === 0 && !isLoading ? (
           <p className="text-gray-400 dark:text-gray-500 text-sm italic text-center py-8">
             No messages yet — click &ldquo;Next Turn&rdquo; to start the conversation.
           </p>
@@ -178,13 +179,27 @@ export function ConversationView({
                 .filter((p) => p.persona_name)
                 .map((p) => [p.persona_name!, p.avatar_url])
             );
-            return messages.map((msg) => (
-              <MessageBubble
-                key={msg.id}
-                message={msg}
-                avatarUrl={avatarMap[msg.persona_name]}
-              />
-            ));
+            return (
+              <>
+                {messages.map((msg) => (
+                  <MessageBubble
+                    key={msg.id}
+                    message={msg}
+                    avatarUrl={avatarMap[msg.persona_name]}
+                  />
+                ))}
+                {isLoading && (
+                  <TypingIndicator
+                    participants={(conversation.participants ?? [])
+                      .filter((p) => p.persona_name)
+                      .map((p) => ({
+                        persona_name: p.persona_name,
+                        avatar_url: p.avatar_url,
+                      }))}
+                  />
+                )}
+              </>
+            );
           })()
         )}
         <div ref={bottomRef} />

--- a/frontend/src/components/conversation/TypingIndicator.tsx
+++ b/frontend/src/components/conversation/TypingIndicator.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+interface Participant {
+  persona_name: string | null;
+  avatar_url?: string | null;
+}
+
+interface TypingIndicatorProps {
+  participants: Participant[];
+}
+
+export function TypingIndicator({ participants }: TypingIndicatorProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    if (participants.length <= 1) return;
+
+    // Cycle through participants every 3 seconds to simulate sequential "thinking"
+    const interval = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % participants.length);
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [participants.length]);
+
+  const currentParticipant = participants[currentIndex] || { persona_name: "AI" };
+  const name = currentParticipant.persona_name || "AI Participant";
+
+  return (
+    <div className="flex gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800 transition-opacity duration-500">
+      {/* Avatar */}
+      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-100 dark:bg-indigo-900 overflow-hidden flex items-center justify-center transition-all duration-500">
+        {currentParticipant.avatar_url ? (
+          <img
+            src={currentParticipant.avatar_url}
+            alt={name}
+            className="object-cover w-full h-full"
+          />
+        ) : (
+          <span className="text-indigo-700 dark:text-indigo-300 font-semibold text-sm">
+            {name.charAt(0).toUpperCase()}
+          </span>
+        )}
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="font-semibold text-sm text-gray-900 dark:text-white transition-all duration-500">
+            {name} is thinking
+          </span>
+        </div>
+        <div className="flex gap-1.5 items-center h-5">
+          <div className="w-2 h-2 bg-indigo-400 dark:bg-indigo-500 rounded-full animate-bounce [animation-delay:-0.3s]"></div>
+          <div className="w-2 h-2 bg-indigo-400 dark:bg-indigo-500 rounded-full animate-bounce [animation-delay:-0.15s]"></div>
+          <div className="w-2 h-2 bg-indigo-400 dark:bg-indigo-500 rounded-full animate-bounce"></div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Users were experiencing a lack of visual feedback during the sequential generation of AI persona responses, leading to concerns that the application had stalled.

I have implemented a `TypingIndicator` component that visually matches the `MessageBubble` style and includes an animated bouncing dots indicator. To better represent the backend's sequential processing, the indicator cycles through the names and avatars of the participating AI personas every 3 seconds.

Key changes:
1. Created `frontend/src/components/conversation/TypingIndicator.tsx`.
2. Modified `frontend/src/components/conversation/ConversationView.tsx` to:
   - Render the `TypingIndicator` when a turn is being generated.
   - Trigger smooth auto-scrolling when the indicator appears.
   - Correctly filter out the human user from the "thinking" feedback cycle.
   - Show the indicator even if the conversation has no messages yet.

Verified with frontend build and existing test suites.

Fixes #93

---
*PR created automatically by Jules for task [6204418031258038157](https://jules.google.com/task/6204418031258038157) started by @JamesTwisleton*