### PR TITLE
Login Modal for Guest Actions

### DIFF
--- a/frontend/src/app/c/[id]/page.tsx
+++ b/frontend/src/app/c/[id]/page.tsx
@@ -15,7 +15,7 @@ import { Conversation, ApiError } from "@/types";
 
 export default function PublicConversationPage() {
   const { id } = useParams<{ id: string }>();
-  const { user } = useAuth();
+  const { user, setLoginModalOpen } = useAuth();
   const [conv, setConv] = useState<Conversation | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -154,26 +154,17 @@ export default function PublicConversationPage() {
               targetType="conversation"
               uniqueId={conv.unique_id}
               initialCount={conv.upvote_count}
-              requiresAuth={!user}
             />
 
-            {user ? (
-              <button
-                onClick={() => setShowFork(true)}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h.01M12 7h.01M16 7h.01M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01" />
-                </svg>
-                Fork
-              </button>
-            ) : (
-              <Link href="/login">
-                <button className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-                  Log in to fork
-                </button>
-              </Link>
-            )}
+            <button
+              onClick={() => (user ? setShowFork(true) : setLoginModalOpen(true))}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:border-indigo-400 hover:text-indigo-600 dark:hover:border-indigo-400 dark:hover:text-indigo-400 transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M8 7h.01M12 7h.01M16 7h.01M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01" />
+              </svg>
+              Fork
+            </button>
 
             {conv.is_owner && (
               <button
@@ -207,11 +198,12 @@ export default function PublicConversationPage() {
         {!user && (
           <div className="mt-8 bg-indigo-50 dark:bg-indigo-900/30 rounded-xl p-5 text-center">
             <p className="text-gray-700 dark:text-gray-300 font-medium mb-3">Want to continue this conversation?</p>
-            <Link href="/login">
-              <button className="px-5 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors">
-                Sign in to fork
-              </button>
-            </Link>
+            <button
+              onClick={() => setLoginModalOpen(true)}
+              className="px-5 py-2 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors"
+            >
+              Sign in to fork
+            </button>
           </div>
         )}
       </div>

--- a/frontend/src/app/p/[id]/page.tsx
+++ b/frontend/src/app/p/[id]/page.tsx
@@ -24,7 +24,7 @@ const SORT_TABS: { key: Sort; label: string }[] = [
 
 export default function PersonaProfilePage() {
   const { id } = useParams<{ id: string }>();
-  const { user } = useAuth();
+  const { user, setLoginModalOpen } = useAuth();
   const [persona, setPersona] = useState<Persona | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -160,7 +160,6 @@ export default function PersonaProfilePage() {
                   targetType="persona"
                   uniqueId={persona.unique_id}
                   initialCount={persona.upvote_count}
-                  requiresAuth={!user}
                 />
               </div>
 
@@ -236,11 +235,12 @@ export default function PersonaProfilePage() {
                     </button>
                   </Link>
                 ) : (
-                  <Link href="/login">
-                    <button className="w-full py-3 px-4 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors">
-                      Log in to start a conversation
-                    </button>
-                  </Link>
+                  <button
+                    onClick={() => setLoginModalOpen(true)}
+                    className="w-full py-3 px-4 bg-indigo-600 text-white rounded-lg font-medium hover:bg-indigo-700 transition-colors"
+                  >
+                    Start a Conversation
+                  </button>
                 )}
                 {persona.is_owner && (
                   <>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -83,7 +83,6 @@ function PersonaFeedCard({ persona, loggedIn }: { persona: Persona; loggedIn: bo
                 targetType="persona"
                 uniqueId={persona.unique_id}
                 initialCount={persona.upvote_count}
-                requiresAuth={!loggedIn}
               />
             </div>
           </div>
@@ -113,7 +112,6 @@ function ConversationFeedCard({ conv, loggedIn }: { conv: Conversation; loggedIn
               targetType="conversation"
               uniqueId={conv.unique_id}
               initialCount={conv.upvote_count}
-              requiresAuth={!loggedIn}
             />
           </div>
         </div>
@@ -123,7 +121,7 @@ function ConversationFeedCard({ conv, loggedIn }: { conv: Conversation; loggedIn
 }
 
 export default function Home() {
-  const { user, isLoading: authLoading } = useAuth();
+  const { user, isLoading: authLoading, setLoginModalOpen } = useAuth();
   const router = useRouter();
   const [personaSort, setPersonaSort] = useState<Sort>("hot");
   const [convSort, setConvSort] = useState<Sort>("hot");
@@ -177,28 +175,30 @@ export default function Home() {
         <p className="text-indigo-100 max-w-xl mx-auto mb-6">
           Build AI personas and run focus group simulations. Discover what others have created.
         </p>
-        {!authLoading && !user && (
-          <div className="flex gap-3 justify-center">
-            <Link href="/login">
-              <button className="px-6 py-2.5 bg-white text-indigo-700 font-semibold rounded-full hover:bg-indigo-50 transition-colors">
-                Sign in with Google
-              </button>
-            </Link>
-          </div>
-        )}
-        {!authLoading && user && (
+        {!authLoading && (
           <div className="flex flex-col items-center gap-6 max-w-2xl mx-auto">
             <div className="flex gap-3 justify-center">
-              <Link href="/personas/new">
-                <button className="px-5 py-2.5 bg-white text-indigo-700 font-semibold rounded-full hover:bg-indigo-50 transition-colors">
-                  + New Persona
+              {user ? (
+                <>
+                  <Link href="/personas/new">
+                    <button className="px-5 py-2.5 bg-white text-indigo-700 font-semibold rounded-full hover:bg-indigo-50 transition-colors">
+                      + New Persona
+                    </button>
+                  </Link>
+                  <Link href="/conversations/new">
+                    <button className="px-5 py-2.5 bg-indigo-500 text-white font-semibold rounded-full hover:bg-indigo-400 transition-colors border border-white/30">
+                      + New Conversation
+                    </button>
+                  </Link>
+                </>
+              ) : (
+                <button
+                  onClick={() => setLoginModalOpen(true)}
+                  className="px-6 py-2.5 bg-white text-indigo-700 font-semibold rounded-full hover:bg-indigo-50 transition-colors shadow-lg"
+                >
+                  Sign in with Google
                 </button>
-              </Link>
-              <Link href="/conversations/new">
-                <button className="px-5 py-2.5 bg-indigo-500 text-white font-semibold rounded-full hover:bg-indigo-400 transition-colors border border-white/30">
-                  + New Conversation
-                </button>
-              </Link>
+              )}
             </div>
 
             <div className="w-full bg-white/10 backdrop-blur-md rounded-2xl p-6 border border-white/20">
@@ -206,6 +206,10 @@ export default function Home() {
               <form
                 onSubmit={async (e) => {
                   e.preventDefault();
+                  if (!user) {
+                    setLoginModalOpen(true);
+                    return;
+                  }
                   const form = e.target as HTMLFormElement;
                   const proposal = (form.elements.namedItem("proposal") as HTMLInputElement).value;
                   const challengeType = (form.elements.namedItem("type") as HTMLSelectElement).value;

--- a/frontend/src/components/auth/LoginModal.tsx
+++ b/frontend/src/components/auth/LoginModal.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuth } from "@/context/AuthContext";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+export function LoginModal() {
+  const { isLoginModalOpen, setLoginModalOpen } = useAuth();
+
+  // Close on Escape
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setLoginModalOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [setLoginModalOpen]);
+
+  if (!isLoginModalOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={() => setLoginModalOpen(false)}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div className="relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-sm w-full p-8 text-center">
+        <div className="mb-6 flex justify-center">
+          <div className="bg-indigo-100 dark:bg-indigo-900/50 p-3 rounded-xl">
+            <svg
+              className="w-8 h-8 text-indigo-600 dark:text-indigo-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+              />
+            </svg>
+          </div>
+        </div>
+
+        <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+          Sign in required
+        </h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          Join PersonaComposer to create personas, start conversations, and upvote your favorites.
+        </p>
+
+        <a
+          href={`${API_URL}/auth/login/google`}
+          className="flex items-center justify-center gap-3 w-full py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors font-semibold text-gray-700 dark:text-gray-200 mb-4"
+        >
+          <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+              fill="#4285F4"
+            />
+            <path
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+              fill="#34A853"
+            />
+            <path
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+              fill="#FBBC05"
+            />
+            <path
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+              fill="#EA4335"
+            />
+          </svg>
+          Continue with Google
+        </a>
+
+        <button
+          onClick={() => setLoginModalOpen(false)}
+          className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 font-medium transition-colors"
+        >
+          Maybe later
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/social/UpvoteButton.tsx
+++ b/frontend/src/components/social/UpvoteButton.tsx
@@ -3,13 +3,13 @@
 import { useState } from "react";
 import { apiFetch } from "@/lib/api";
 import { ApiError } from "@/types";
+import { useAuth } from "@/context/AuthContext";
 
 interface UpvoteButtonProps {
   targetType: "persona" | "conversation";
   uniqueId: string;
   initialCount: number;
   initialUpvoted?: boolean;
-  requiresAuth?: boolean;
 }
 
 export function UpvoteButton({
@@ -17,8 +17,8 @@ export function UpvoteButton({
   uniqueId,
   initialCount,
   initialUpvoted = false,
-  requiresAuth = false,
 }: UpvoteButtonProps) {
+  const { user, setLoginModalOpen } = useAuth();
   const [count, setCount] = useState(initialCount);
   const [upvoted, setUpvoted] = useState(initialUpvoted);
   const [loading, setLoading] = useState(false);
@@ -26,7 +26,10 @@ export function UpvoteButton({
   const prefix = targetType === "persona" ? "p" : "c";
 
   const handleClick = async () => {
-    if (requiresAuth) return;
+    if (!user) {
+      setLoginModalOpen(true);
+      return;
+    }
     if (loading) return;
     setLoading(true);
     try {
@@ -48,8 +51,8 @@ export function UpvoteButton({
   return (
     <button
       onClick={handleClick}
-      disabled={loading || requiresAuth}
-      title={requiresAuth ? "Log in to upvote" : upvoted ? "Remove upvote" : "Upvote"}
+      disabled={loading}
+      title={upvoted ? "Remove upvote" : "Upvote"}
       className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors border ${
         upvoted
           ? "bg-indigo-600 text-white border-indigo-600"

--- a/frontend/src/components/social/__tests__/UpvoteButton.test.tsx
+++ b/frontend/src/components/social/__tests__/UpvoteButton.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { UpvoteButton } from "../UpvoteButton";
 import { apiFetch } from "@/lib/api";
+import { useAuth } from "@/context/AuthContext";
+
+// Mock useAuth
+jest.mock("@/context/AuthContext", () => ({
+  useAuth: jest.fn(),
+}));
 
 // Mock apiFetch
 jest.mock("@/lib/api", () => ({
@@ -17,6 +23,10 @@ describe("UpvoteButton", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (useAuth as jest.Mock).mockReturnValue({
+      user: { id: 1, email: "test@example.com" },
+      setLoginModalOpen: jest.fn(),
+    });
   });
 
   it("renders the initial count", () => {

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -4,11 +4,14 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 import { User, ApiError } from "@/types";
 import { getToken, setToken, clearToken } from "@/lib/auth";
 import { apiFetch } from "@/lib/api";
+import { LoginModal } from "@/components/auth/LoginModal";
 
 interface AuthContextValue {
   user: User | null;
   token: string | null;
   isLoading: boolean;
+  isLoginModalOpen: boolean;
+  setLoginModalOpen: (open: boolean) => void;
   login: (token: string) => Promise<void>;
   logout: () => void;
 }
@@ -19,6 +22,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [token, setTokenState] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [isLoginModalOpen, setLoginModalOpen] = useState(false);
 
   useEffect(() => {
     const storedToken = getToken();
@@ -62,8 +66,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, isLoading, login, logout }}>
+    <AuthContext.Provider
+      value={{
+        user,
+        token,
+        isLoading,
+        isLoginModalOpen,
+        setLoginModalOpen,
+        login,
+        logout,
+      }}
+    >
       {children}
+      <LoginModal />
     </AuthContext.Provider>
   );
 }


### PR DESCRIPTION
This change improves the user experience for unauthenticated users by replacing abrupt redirects to the login page with a modal suggesting they sign in when they perform actions like upvoting, starting a conversation, or forking. It also makes the 'Challenge Mode' more discoverable by showing it to guests on the home page.

Fixes #111

---
*PR created automatically by Jules for task [6323653987129339268](https://jules.google.com/task/6323653987129339268) started by @JamesTwisleton*